### PR TITLE
Timezone bug fix

### DIFF
--- a/TODOs.xcodeproj/xcshareddata/xcschemes/[DEV] TODOs.xcscheme
+++ b/TODOs.xcodeproj/xcshareddata/xcschemes/[DEV] TODOs.xcscheme
@@ -59,6 +59,13 @@
             ReferencedContainer = "container:TODOs.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TZ"
+            value = "EST"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/TODOs.xcodeproj/xcshareddata/xcschemes/[DEV] TODOs.xcscheme
+++ b/TODOs.xcodeproj/xcshareddata/xcschemes/[DEV] TODOs.xcscheme
@@ -62,7 +62,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "TZ"
-            value = "PST"
+            value = "EST"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/TODOs.xcodeproj/xcshareddata/xcschemes/[DEV] TODOs.xcscheme
+++ b/TODOs.xcodeproj/xcshareddata/xcschemes/[DEV] TODOs.xcscheme
@@ -62,7 +62,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "TZ"
-            value = "EST"
+            value = "PST"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/TODOs/Classes/Models/TodoList.swift
+++ b/TODOs/Classes/Models/TodoList.swift
@@ -49,7 +49,7 @@ class TodoList: Codable {
     
     init(
         classification: Classification,
-        dateCreated: Date = .todayYearMonthDay(),
+        dateCreated: Date = Date(),
         name: String,
         todos: [Todo] = [],
         showCompleted: Bool = !GeneralSettings.shared.hideCompleted

--- a/TODOs/Classes/View Controllers/TodosContainerViewController.swift
+++ b/TODOs/Classes/View Controllers/TodosContainerViewController.swift
@@ -143,7 +143,7 @@ extension TodosContainerViewController {
     }
 
     @objc func willResignActive() {
-        try? TodoList.saveCreated(createdTodoViewController.dataSource.todoLists)
+//        try? TodoList.saveCreated(createdTodoViewController.dataSource.todoLists)
         try? TodoList.saveDaysOfWeek(daysOfWeekTodoController.dataSource.todoLists)
     }
 
@@ -151,7 +151,7 @@ extension TodosContainerViewController {
         guard let firstDay = daysOfWeekTodoController.dataSource.todoLists.first else {
             fatalError("First day should be set")
         }
-        if Date.todayYearMonthDay() > firstDay.dateCreated {
+        if firstDay.dateCreated.isBefore(Date()) {
             daysOfWeekTodoController.updateTodoLists(TodoList.daysOfWeekTodoLists())
         }
     }

--- a/TODOs/Classes/View Controllers/TodosContainerViewController.swift
+++ b/TODOs/Classes/View Controllers/TodosContainerViewController.swift
@@ -143,7 +143,7 @@ extension TodosContainerViewController {
     }
 
     @objc func willResignActive() {
-//        try? TodoList.saveCreated(createdTodoViewController.dataSource.todoLists)
+        try? TodoList.saveCreated(createdTodoViewController.dataSource.todoLists)
         try? TodoList.saveDaysOfWeek(daysOfWeekTodoController.dataSource.todoLists)
     }
 

--- a/TODOs/Extensions/Date+Extensions.swift
+++ b/TODOs/Extensions/Date+Extensions.swift
@@ -9,7 +9,16 @@
 import Foundation
 
 extension Date {
-    static func from(year: Int, month: Int, day: Int, calendar: Calendar = .current) -> Date {
+    static func todayYearMonthDay(calendar: Calendar = .current) -> Date {
+        let today = Date()
+        return Date.from(
+            year: calendar.component(.year, from: today),
+            month: calendar.component(.month, from: today),
+            day: calendar.component(.day, from: today)
+        )
+    }
+
+    private static func from(year: Int, month: Int, day: Int, calendar: Calendar = .current) -> Date {
         var components = DateComponents()
         components.year = year
         components.month = month
@@ -18,15 +27,6 @@ extension Date {
             preconditionFailure("Invalid Date")
         }
         return date
-    }
-
-    static func todayYearMonthDay(calendar: Calendar = .current) -> Date {
-        let today = Date()
-        return Date.from(
-            year: calendar.component(.year, from: today),
-            month: calendar.component(.month, from: today),
-            day: calendar.component(.day, from: today)
-        )
     }
 
     func byAddingDays(_ day: Int, calendar: Calendar = .current) -> Date {

--- a/TODOs/Extensions/Date+Extensions.swift
+++ b/TODOs/Extensions/Date+Extensions.swift
@@ -10,8 +10,8 @@ import Foundation
 
 extension Date {
     /// calendar.compare.toGranularity(.day) should work, and is working in playground but still not getting what I want with below date objs
-    /// " today2021-01-16 08:00:00 +0000"
-    /// "created 2021-01-16 05:00:00 +0000" - still got .orderedAscending
+    /// " today 2021-01-16 08:00:00 +0000"
+    /// "created 2021-01-16 05:00:00 +0000", still got .orderedAscending instead of .same for day comparison
     func isBefore(_ before: Date, calendar: Calendar = .current) -> Bool {
         let dMonth = calendar.component(.month, from: self)
         let dDay = calendar.component(.day, from: self)

--- a/TODOs/Extensions/Date+Extensions.swift
+++ b/TODOs/Extensions/Date+Extensions.swift
@@ -18,6 +18,13 @@ extension Date {
         )
     }
 
+    func byAddingDays(_ day: Int, calendar: Calendar = .current) -> Date {
+        guard let n = Calendar.current.date(byAdding: .day, value: day, to: self) else {
+            preconditionFailure()
+        }
+        return n
+    }
+
     private static func from(year: Int, month: Int, day: Int, calendar: Calendar = .current) -> Date {
         var components = DateComponents()
         components.year = year
@@ -27,12 +34,5 @@ extension Date {
             preconditionFailure("Invalid Date")
         }
         return date
-    }
-
-    func byAddingDays(_ day: Int, calendar: Calendar = .current) -> Date {
-        guard let n = Calendar.current.date(byAdding: .day, value: day, to: self) else {
-            preconditionFailure()
-        }
-        return n
     }
 }

--- a/TODOs/Extensions/Date+Extensions.swift
+++ b/TODOs/Extensions/Date+Extensions.swift
@@ -9,13 +9,33 @@
 import Foundation
 
 extension Date {
-    static func todayYearMonthDay(calendar: Calendar = .current) -> Date {
-        let today = Date()
-        return Date.from(
-            year: calendar.component(.year, from: today),
-            month: calendar.component(.month, from: today),
-            day: calendar.component(.day, from: today)
-        )
+    /// calendar.compare.toGranularity(.day) should work, and is working in playground but still not getting what I want with below date objs
+    /// " today2021-01-16 08:00:00 +0000"
+    /// "created 2021-01-16 05:00:00 +0000" - still got .orderedAscending
+    func isBefore(_ before: Date, calendar: Calendar = .current) -> Bool {
+        let dMonth = calendar.component(.month, from: self)
+        let dDay = calendar.component(.day, from: self)
+        let dYear = calendar.component(.year, from: self)
+        let tMonth = calendar.component(.month, from: before)
+        let tDay = calendar.component(.day, from: before)
+        let tYear = calendar.component(.year, from: before)
+        /// year check
+        if dYear < tYear {
+            return true
+        } else if dYear > tYear {
+            return false
+        }
+        /// month, days in same year established
+        if dMonth < tMonth {
+            return true
+        } else if dMonth > tMonth {
+            return false
+        }
+        /// day, days in same month established
+        if dDay < tDay {
+            return true
+        }
+        return false
     }
 
     func byAddingDays(_ day: Int, calendar: Calendar = .current) -> Date {
@@ -23,16 +43,5 @@ extension Date {
             preconditionFailure()
         }
         return n
-    }
-
-    private static func from(year: Int, month: Int, day: Int, calendar: Calendar = .current) -> Date {
-        var components = DateComponents()
-        components.year = year
-        components.month = month
-        components.day = day
-        guard let date = calendar.date(from: components) else {
-            preconditionFailure("Invalid Date")
-        }
-        return date
     }
 }

--- a/TODOs/TodoList+Extensions.swift
+++ b/TODOs/TodoList+Extensions.swift
@@ -20,7 +20,6 @@ extension TodoList {
 
     static func daysOfWeekTodoLists(
         calendar: Calendar = .current,
-        today: Date = .todayYearMonthDay(),
         settings: GeneralSettings = .shared
     ) -> [TodoList] {
         guard var lists = try? getDaysOfWeek(), !lists.isEmpty else {
@@ -29,11 +28,9 @@ extension TodoList {
         let current = currentDaysOfWeek()
         var i = 0
         var mDay = lists.last!.dateCreated
-
         while i < current.count {
-            let result = calendar.compare(lists[i].dateCreated, to: today, toGranularity: .day)
-            switch result {
-            case .orderedAscending:
+            let today = Date()
+            if lists[i].dateCreated.isBefore(today) {
                 let removed = lists.remove(at: i)
                 let newDay = mDay.byAddingDays(1)
                 let newList = TodoList(
@@ -49,7 +46,7 @@ extension TodoList {
                     // could have setting to rollover settings
                     lists[i].todos.append(contentsOf: prev)
                 }
-            case .orderedDescending, .orderedSame:
+            } else {
                 i += 1
             }
         }
@@ -58,7 +55,7 @@ extension TodoList {
 
     static func newDaysOfWeekTodoLists(
         calendar: Calendar = .current,
-        today: Date = .todayYearMonthDay()
+        today: Date = Date()
     ) -> [TodoList] {
         return currentDaysOfWeek().enumerated().map { offset, day in
             TodoList(
@@ -80,6 +77,11 @@ extension TodoList {
     }
 
     static func saveDaysOfWeek(_ lists: [TodoList]) throws {
+        print("SAVE!")
+        print(lists.forEach {
+                $0.todos.prettyPrint()
+            print($0.dateCreated)
+        })
         try Cache.save(lists, path: "week")
         /// save in AppGroup for widget
         /// may not be the best place to put this - SRP

--- a/TODOs/TodoList+Extensions.swift
+++ b/TODOs/TodoList+Extensions.swift
@@ -77,11 +77,6 @@ extension TodoList {
     }
 
     static func saveDaysOfWeek(_ lists: [TodoList]) throws {
-        print("SAVE!")
-        print(lists.forEach {
-                $0.todos.prettyPrint()
-            print($0.dateCreated)
-        })
         try Cache.save(lists, path: "week")
         /// save in AppGroup for widget
         /// may not be the best place to put this - SRP

--- a/TODOs/TodoList+Extensions.swift
+++ b/TODOs/TodoList+Extensions.swift
@@ -25,11 +25,12 @@ extension TodoList {
         guard var lists = try? getDaysOfWeek(), !lists.isEmpty else {
             return newDaysOfWeekTodoLists()
         }
+        let today = Date()
         let current = currentDaysOfWeek()
         var i = 0
         var mDay = lists.last!.dateCreated
+
         while i < current.count {
-            let today = Date()
             if lists[i].dateCreated.isBefore(today) {
                 let removed = lists.remove(at: i)
                 let newDay = mDay.byAddingDays(1)

--- a/TODOs/TodoList+Extensions.swift
+++ b/TODOs/TodoList+Extensions.swift
@@ -26,12 +26,14 @@ extension TodoList {
         guard var lists = try? getDaysOfWeek(), !lists.isEmpty else {
             return newDaysOfWeekTodoLists()
         }
-
         let current = currentDaysOfWeek()
         var i = 0
         var mDay = lists.last!.dateCreated
+
         while i < current.count {
-            if lists[i].dateCreated < today {
+            let result = calendar.compare(lists[i].dateCreated, to: today, toGranularity: .day)
+            switch result {
+            case .orderedAscending:
                 let removed = lists.remove(at: i)
                 let newDay = mDay.byAddingDays(1)
                 let newList = TodoList(
@@ -44,9 +46,10 @@ extension TodoList {
                 // check if day before for rollover items
                 if settings.rollover, calendar.dateComponents([.day], from: removed.dateCreated, to: today).day == 1 {
                     let prev = removed.todos.filter { !$0.completed && !$0.isSetting }
+                    // could have setting to rollover settings
                     lists[i].todos.append(contentsOf: prev)
                 }
-            } else {
+            case .orderedDescending, .orderedSame:
                 i += 1
             }
         }

--- a/TODOsWidget/TODOsWidget.swift
+++ b/TODOsWidget/TODOsWidget.swift
@@ -56,7 +56,7 @@ struct TodayEntry: TimelineEntry {
     let configuration: ConfigurationIntent
 
     init(
-        date: Date = Date.todayYearMonthDay(),
+        date: Date = Date(),
         today: TodoList,
         configuration: ConfigurationIntent
     ) {


### PR DESCRIPTION
Fixes this annoying bug where when if you changed timezones (noticed after flights awhile ago). The current day items would get deleted or added to the next day. The hours were getting compared and the current day was either before or after the new timezones current day because.

I'm creating these dates with date components and no hours and minutes so I (naively) thought that there was no hour on these date objects. Using calendar compare + day granularity solves this and is more elegant than doing date compares w/ `<` `>` `==`